### PR TITLE
poopcam rate limiting added

### DIFF
--- a/poopcam.ts
+++ b/poopcam.ts
@@ -3,6 +3,7 @@ import { Config, JsonDB } from "node-json-db";
 export type PoopCammer = {
     userName: string;
     requestCount: number;
+    date: Date;
 };
 
 export abstract class PoopCam {
@@ -28,14 +29,25 @@ export abstract class PoopCam {
         }
 
         if (cammer === undefined) {
-            cammer = {userName: userName, requestCount: 0};
+            cammer = {userName: userName, requestCount: 0, date: new Date(0)};
 
         }
-
-        cammer.requestCount++;
+        let date: Date = new Date();
+        let rate_limit = false;
+        if (cammer.date === undefined) {
+            rate_limit = true;
+        } else {
+            rate_limit = (cammer.date.getTime() + 60000 < date.getTime()); //rate limit of 1 min
+        }
+        if (rate_limit) { 
+            cammer.requestCount++;
+        }
+        cammer.date = date;
         let key = this.#cammers_key.concat('[', index.toString(),']');
         await this.#db.push(key, cammer);
-        await this.#db.push(this.#total_key, (await this.getTotalRequests()) + 1);
+        if (rate_limit) { 
+            await this.#db.push(this.#total_key, (await this.getTotalRequests()) + 1);
+        }
     }
 
     static async getTotalRequests(): Promise<number> {

--- a/poopcam.ts
+++ b/poopcam.ts
@@ -33,19 +33,19 @@ export abstract class PoopCam {
 
         }
         let date: Date = new Date();
-        let rate_limit = false;
+        let rate_limited = true;
         if (cammer.date === undefined) {
-            rate_limit = true;
+            rate_limited = false;
         } else {
-            rate_limit = (cammer.date.getTime() + 60000 < date.getTime()); //rate limit of 1 min
+            rate_limited = (cammer.date.getTime() + 60000 > date.getTime()); //rate limit of 1 min
         }
-        if (rate_limit) { 
+        if (!rate_limited) { 
             cammer.requestCount++;
         }
         cammer.date = date;
         let key = this.#cammers_key.concat('[', index.toString(),']');
         await this.#db.push(key, cammer);
-        if (rate_limit) { 
+        if (!rate_limited) { 
             await this.#db.push(this.#total_key, (await this.getTotalRequests()) + 1);
         }
     }


### PR DESCRIPTION
discourages admin users from repeatedly spamming the chat with poopcam requests any poopcam requests that are made within 1 min of the previous do not increase their request counter additionally, these false requests still count towards the last you made your request code also provided to handle instances where existing users in the save file dont have a listed date entry